### PR TITLE
Refactor of /search route

### DIFF
--- a/patt/src/actions/index.js
+++ b/patt/src/actions/index.js
@@ -16,7 +16,10 @@ export const register = creds => dispatch => {
                 localStorage.setItem('username', creds.username)
                 dispatch({
                     type: REGISTER_SUCCESS,
-                    payload: {message: `Succesfully registered ${creds.username}`, userId: res.data.id}
+                    payload: {
+                        message: `Succesfully registered ${creds.username}`, 
+                        userId: res.data.id
+                    }
                 })
             })
             .catch(err => {
@@ -43,7 +46,11 @@ export const login = creds => dispatch => {
                 localStorage.setItem('token', res.data.token)
                 dispatch({
                     type: LOGIN_SUCCESS,
-                    payload: {message: res.data.message, userId: res.data.userId, username: res.data.username}
+                    payload: {
+                        message: res.data.message, 
+                        userId: res.data.userId, 
+                        username: res.data.username
+                    }
                 })
             })
             .catch(err => {

--- a/patt/src/actions/index.js
+++ b/patt/src/actions/index.js
@@ -38,11 +38,12 @@ export const login = creds => dispatch => {
     return axios 
             .post('https://pyschographic-analysis-of-text.herokuapp.com/users/login/', creds)
             .then(res => {
+                console.log(res.data.username)
                 console.log(res.data.message)
                 localStorage.setItem('token', res.data.token)
                 dispatch({
                     type: LOGIN_SUCCESS,
-                    payload: {message: res.data.message, userId: res.data.userId}
+                    payload: {message: res.data.message, userId: res.data.userId, username: res.data.username}
                 })
             })
             .catch(err => {
@@ -135,18 +136,28 @@ export const updateProfile = profileUpdates => dispatch => {
  export const SEARCH_START = 'SEARCH_START'
  export const SEARCH_SUCCESS = 'SEARCH_SUCCESS' 
  export const SEARCH_ERROR = 'SEARCH_ERROR' 
+ export const SEARCH_INPUT = 'SEARCH_INPUT' 
  
+export const grabSearchInput = twitter_name => dispatch => {
+    dispatch({ 
+        type: SEARCH_INPUT,
+        payload: twitter_name 
+    })
+}
+
  export const searching = username => dispatch => { 
-     dispatch({ type: SEARCH_START })
+     dispatch({ 
+         type: SEARCH_START
+        })
      return axios  
           
              .get(`https://pyschographic-analysis-of-text.herokuapp.com/api/users/${username}`)
              .then(res => { 
                  console.log(res) 
-                //  dispatch({ 
-                //      type: SEARCH_SUCCESS, 
-                //      payload: res.data 
-                // }) 
+                 dispatch({ 
+                     type: SEARCH_SUCCESS, 
+                     payload: {message: `Succesfully loaded the results for ${username} from the AI`, searchResults: res.data} 
+                }) 
              }) 
              .catch(err => { 
                  console.log(err) 

--- a/patt/src/components/DataCard.js
+++ b/patt/src/components/DataCard.js
@@ -62,8 +62,8 @@ class DataCard extends React.Component {
     displayedData: ''
   }
   componentDidMount() {
-    this.props.searching("austen")
     setTimeout(() => {
+      this.props.searching(`${this.props.username}`)
       this.setState({
         data: this.props.searchResults.personality,
         displayedData: 'Personality'
@@ -73,7 +73,7 @@ class DataCard extends React.Component {
   clickHandler = e => {
     e.preventDefault()
     this.setState({
-      data: this.dataProviderLogic(e.target.id),
+      data: this.dataProviderLogic(this.state.displayedData),
       displayedData: e.target.id
     })
   }
@@ -108,6 +108,9 @@ class DataCard extends React.Component {
     // })
     return (
       <DataCardWrapper>
+        {!this.props.searchLoaded ? <p>'Making a very impressive request to our AI. Calculating live scores now...'</p> : null}
+        {this.props.searchLoaded && 
+        <>
         <HeaderTitle>@</HeaderTitle>
         <TabNavWrapper>
           <TabNav id="Personality" onClick={this.clickHandler}>
@@ -127,10 +130,8 @@ class DataCard extends React.Component {
         {this.state.displayedData}
           {/* <p>{legend}</p> */}
         </div>
-        <Link to="/search">
-          <SearchAgainButton>Search again</SearchAgainButton>
-        </Link>
-
+        </>
+        }
       </DataCardWrapper>
     );
   }
@@ -139,7 +140,10 @@ class DataCard extends React.Component {
 const mapStateToProps = state => ({
   error: state.error,
   searching: state.searching,
-  searchResults: state.searchResults
+  searchResults: state.searchResults,
+  searchInput: state.searchInput,
+  username: state.username,
+  searchLoaded: state.searchLoaded
 })
 
 export default connect(

--- a/patt/src/components/DataCard.js
+++ b/patt/src/components/DataCard.js
@@ -59,16 +59,10 @@ const TabNav = styled.div`
 class DataCard extends React.Component {
   state = {
     data: [],
-    displayedData: ''
+    displayedData: 'Personality'
   }
   componentDidMount() {
-    setTimeout(() => {
-      this.props.searching(`${this.props.username}`)
-      this.setState({
-        data: this.props.searchResults.personality,
-        displayedData: 'Personality'
-      })
-    }, 500)
+    this.loadData()
   }
   clickHandler = e => {
     e.preventDefault()
@@ -94,24 +88,32 @@ class DataCard extends React.Component {
     const legendTitle = (legendKey.charAt(0).toUpperCase() + legendKey.slice(1).replace(/[^a-zA-Z ]/g, " "))
     return legendTitle
   }
+  loadData = () => {
+    this.props.searching(`${this.props.username}`)
+      .then(() =>{
+        this.setState({
+          data: this.dataProviderLogic(this.state.displayedData)
+      })
+    })
+  }
   render() {
-    // const obj = this.state.data
-    // const objOfArr = Object.keys(obj).map(key => {
-    //     return {
-    //         key: this.legendTitleCapitalizer(key),
-    //         value: obj[key]
-    //     }
-    // })
-    // const profileData = this.props.searchResults
-    // const legend = objOfArr.map((data, i) => {
-    //   return <p key={i}>{this.legendTitleCapitalizer(data.key)}: %{this.percentileProviderLogic(data.value)}</p>
-    // })
+    const obj = this.state.data
+    const objOfArr = Object.keys(obj).map(key => {
+        return {
+            key: this.legendTitleCapitalizer(key),
+            value: obj[key]
+        }
+    })
+    const legend = objOfArr.map((data, i) => {
+      return <p key={i}>{this.legendTitleCapitalizer(data.key)}: %{this.percentileProviderLogic(data.value)}</p>
+    })
+    console.log(objOfArr)
     return (
       <DataCardWrapper>
         {!this.props.searchLoaded ? <p>'Making a very impressive request to our AI. Calculating live scores now...'</p> : null}
         {this.props.searchLoaded && 
         <>
-        <HeaderTitle>@</HeaderTitle>
+        <HeaderTitle>@{this.props.searchResults.username}</HeaderTitle>
         <TabNavWrapper>
           <TabNav id="Personality" onClick={this.clickHandler}>
             Personality
@@ -124,11 +126,11 @@ class DataCard extends React.Component {
           </TabNav>
           </TabNavWrapper>
           <div>
-            <SingleUserTraitsGraph />
+            {this.state.displayedData &&<SingleUserTraitsGraph data={objOfArr} /> }
           </div>
         <div>
         {this.state.displayedData}
-          {/* <p>{legend}</p> */}
+          <p>{legend}</p>
         </div>
         </>
         }

--- a/patt/src/components/SearchForm.js
+++ b/patt/src/components/SearchForm.js
@@ -96,6 +96,7 @@ class SearchForm extends React.Component {
   // Search function calls our action 
   search = e => {
     e.preventDefault()
+    this.props.grabSearchInput(this.state.username.search)
     console.log(this.state.username.search); 
     this.props.searching(this.state.username.search)
       .then(() => {
@@ -109,7 +110,7 @@ class SearchForm extends React.Component {
     {this.props.message &&
     setTimeout(() => 
   this.props.history.push('/search-results')
-, 2000)}
+, 1000)}
   }
 
     render() {

--- a/patt/src/components/SingleUserTraitsGraph.js
+++ b/patt/src/components/SingleUserTraitsGraph.js
@@ -11,6 +11,7 @@ export default function SingleUserTraitsGraph(props) {
             padding={{top:100, bottom:100, right:100, left:100}}
              >
                 <VictoryArea
+                data={props.data}
                 x='key'
                 y="value"
                 animate

--- a/patt/src/pages/SearchPage.js
+++ b/patt/src/pages/SearchPage.js
@@ -1,6 +1,6 @@
 import React from 'react'; 
 import { SearchForm, SettingsButton } from '../components'; 
-import DataCardPage from './DataCardPage'
+import DataCard from '../components/DataCard'
 
 class SearchPage extends React.Component {
     render() {
@@ -8,7 +8,7 @@ class SearchPage extends React.Component {
             <> 
             <SettingsButton /> 
             <SearchForm /> 
-            <DataCardPage /> 
+            <DataCard /> 
             </> 
 
             )

--- a/patt/src/reducers/index.js
+++ b/patt/src/reducers/index.js
@@ -1,4 +1,4 @@
-import { REGISTER_START, REGISTER_SUCCESS, REGISTER_ERROR, LOGIN_START, LOGIN_SUCCESS, LOGIN_ERROR, LOG_OUT_START, LOG_OUT_SUCCESS, CAPTURE_PROFILE, DELETE_PROFILE_SUCCESS, DELETE_PROFILE_START, DELETE_PROFILE_ERROR, UPDATE_PROFILE_START, UPDATE_PROFILE_SUCCESS, UPDATE_PROFILE_ERROR, SEARCH_START, SEARCH_SUCCESS, SEARCH_ERROR } from '../actions'
+import { REGISTER_START, REGISTER_SUCCESS, REGISTER_ERROR, LOGIN_START, LOGIN_SUCCESS, LOGIN_ERROR, LOG_OUT_START, LOG_OUT_SUCCESS, CAPTURE_PROFILE, DELETE_PROFILE_SUCCESS, DELETE_PROFILE_START, DELETE_PROFILE_ERROR, UPDATE_PROFILE_START, UPDATE_PROFILE_SUCCESS, UPDATE_PROFILE_ERROR, SEARCH_START, SEARCH_SUCCESS, SEARCH_ERROR, SEARCH_INPUT } from '../actions'
 
 const initialState = {
     registering: false,
@@ -9,8 +9,11 @@ const initialState = {
     message: null,
     profile: null,
     userId: null,
+    username: null,
     searching: null,
-    searchResults: []
+    searchResults: [],
+    searchInput: '',
+    searchLoaded: null
 }
 
 const rootReducer = (state = initialState, action) => {
@@ -48,7 +51,8 @@ const rootReducer = (state = initialState, action) => {
           loggingIn: false,
           error: "",
           message: action.payload.message,
-          userId: action.payload.userId
+          userId: action.payload.userId,
+          username: action.payload.username
         };
       case LOGIN_ERROR:
         return {
@@ -113,25 +117,32 @@ const rootReducer = (state = initialState, action) => {
       case SEARCH_START:
         return {
           ...state,
-          searching: true,
           message: "",
-          error: "" 
+          error: "",
+          searchLoaded: false 
         };
       case SEARCH_SUCCESS:
         return {
           ...state,
-          searching: false,
           message: action.payload.message, 
           error: "",
-          searchResults: action.payload.searchResults
+          searchResults: action.payload.searchResults,
+          searchLoaded: true
         };
       case SEARCH_ERROR:
         return {
           ...state,
-          searching: false,
           message: "",
-          error: action.payload
+          error: action.payload,
+          searchLoaded: false 
         };
+      case SEARCH_INPUT:
+        return {
+          ...state,
+          searching: true,
+          message: '',
+          searchInput: action.payload
+        }
       default:
         return state;
     } 


### PR DESCRIPTION
The Search Page component has been refactored to accomplish the goal of resembling the newly proposed mock design/functionality. 

Before - A registered user is pushed from either log in or register page to the search page. A search bar shows and after entering in text is pushed to a search-results page.

Now- Same process above, except for the search page and search-results page live in the same route. Using conditional rendering, the data is now effectively rendered on page after making the .get request to the ML model API. 