### PR TITLE
Reformat of seach page component

### DIFF
--- a/patt/package.json
+++ b/patt/package.json
@@ -9,6 +9,7 @@
     "react-redux": "^7.0.3",
     "react-router-dom": "^5.0.0",
     "react-scripts": "3.0.1",
+    "react-sweet-progress": "^1.1.2",
     "redux": "^4.0.1",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",

--- a/patt/src/components/DataCard.js
+++ b/patt/src/components/DataCard.js
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux'
 import { searching } from '../actions'
 import SingleUserTraitsGraph from './SingleUserTraitsGraph'
+import TraitsLegend from './TraitsLegend'
 
 const DataCardWrapper = styled.div`
     background-color: white; 
@@ -21,6 +22,7 @@ const DataCardWrapper = styled.div`
 // For refactoring: create a custom React component that takes prop, and those props will be string of title
 const HeaderTitle = styled.h2`
     color: #0082c9; 
+    display: flex;
 `; 
 
 // Logo 
@@ -58,17 +60,15 @@ const TabNav = styled.div`
 
 class DataCard extends React.Component {
   state = {
-    data: [],
     displayedData: 'Personality'
   }
   componentDidMount() {
-    this.loadData()
+    this.props.searching(`${this.props.username}`)
   }
   clickHandler = e => {
     e.preventDefault()
     this.setState({
       displayedData: e.target.id,
-      data: this.dataProviderLogic(e.target.id)
     })
   }
   dataProviderLogic = dataName => {
@@ -80,50 +80,14 @@ class DataCard extends React.Component {
       return this.props.searchResults.values
     }
   }
-  percentileProviderLogic = integer => {
-    const percentile = (integer * 100).toFixed(2)
-    return percentile
-  }
-  legendTitleCapitalizer = legendKey => {
-    const legendTitle = (legendKey.charAt(0).toUpperCase() + legendKey.slice(1).replace(/[^a-zA-Z ]/g, " "))
-    return legendTitle
-  }
-  loadData = () => {
-    this.props.searching(`${this.props.username}`)
-    this.setState({
-      data: this.props.searchResults.personality
-    })
-  }
-  chartDataFormat = () => {
-    const obj = this.state.data
-    const objOfArr = Object.keys(obj).map(key => {
-        return {
-            key: this.legendTitleCapitalizer(key),
-            value: obj[key]
-        }
-    })
-    return objOfArr
-  } 
-  legendDataFormat = () => {
-    const obj = this.state.data
-    const objOfArr = Object.keys(obj).map(key => {
-        return {
-            key: this.legendTitleCapitalizer(key),
-            value: obj[key]
-        }
-    })
-    const legend = objOfArr.map((data, i) => {
-      return <p key={i}>{this.legendTitleCapitalizer(data.key)}: %{this.percentileProviderLogic(data.value)}</p>
-    })
-    return legend
-  }
+
   render() {
     return (
       <DataCardWrapper>
-        {!this.props.searchLoaded ? <p>'Making a very impressive request to our AI. Calculating live scores now...'</p> : null}
+        {!this.props.searchLoaded && <p>'Making a very impressive request to our AI. Calculating live scores now...'</p>}
         {this.props.searchLoaded && 
         <>
-        <HeaderTitle><img style={{width: '5vw', borderRadius: '50%'}} src={this.props.searchResults.image_url} alt="twitter profile picture" />@{this.props.searchResults.username}</HeaderTitle>
+        <HeaderTitle>@{this.props.searchResults.username}</HeaderTitle>
         <TabNavWrapper>
           <TabNav id="Personality" onClick={this.clickHandler}>
             Personality
@@ -136,11 +100,11 @@ class DataCard extends React.Component {
           </TabNav>
           </TabNavWrapper>
           <div>
-            {this.state.displayedData &&<SingleUserTraitsGraph data={this.chartDataFormat()} /> }
+            {this.state.displayedData && <SingleUserTraitsGraph data={this.dataProviderLogic(this.state.displayedData)} /> }
           </div>
         <div>
         {this.state.displayedData}
-        {this.legendDataFormat()}
+        <TraitsLegend profilePic={this.props.searchResults.image_url} data={this.dataProviderLogic(this.state.displayedData)}/>
         </div>
         </>
         }
@@ -149,14 +113,17 @@ class DataCard extends React.Component {
   }
 }
 
-const mapStateToProps = state => ({
+
+
+const mapStateToProps = state => {
+  return {
   error: state.error,
   searching: state.searching,
   searchResults: state.searchResults,
   searchInput: state.searchInput,
   username: state.username,
-  searchLoaded: state.searchLoaded
-})
+  searchLoaded: state.searchLoaded,
+}}
 
 export default connect(
   mapStateToProps,

--- a/patt/src/components/DataCard.js
+++ b/patt/src/components/DataCard.js
@@ -67,8 +67,8 @@ class DataCard extends React.Component {
   clickHandler = e => {
     e.preventDefault()
     this.setState({
-      data: this.dataProviderLogic(this.state.displayedData),
-      displayedData: e.target.id
+      displayedData: e.target.id,
+      data: this.dataProviderLogic(e.target.id)
     })
   }
   dataProviderLogic = dataName => {
@@ -90,13 +90,21 @@ class DataCard extends React.Component {
   }
   loadData = () => {
     this.props.searching(`${this.props.username}`)
-      .then(() =>{
-        this.setState({
-          data: this.dataProviderLogic(this.state.displayedData)
-      })
+    this.setState({
+      data: this.props.searchResults.personality
     })
   }
-  render() {
+  chartDataFormat = () => {
+    const obj = this.state.data
+    const objOfArr = Object.keys(obj).map(key => {
+        return {
+            key: this.legendTitleCapitalizer(key),
+            value: obj[key]
+        }
+    })
+    return objOfArr
+  } 
+  legendDataFormat = () => {
     const obj = this.state.data
     const objOfArr = Object.keys(obj).map(key => {
         return {
@@ -107,13 +115,15 @@ class DataCard extends React.Component {
     const legend = objOfArr.map((data, i) => {
       return <p key={i}>{this.legendTitleCapitalizer(data.key)}: %{this.percentileProviderLogic(data.value)}</p>
     })
-    console.log(objOfArr)
+    return legend
+  }
+  render() {
     return (
       <DataCardWrapper>
         {!this.props.searchLoaded ? <p>'Making a very impressive request to our AI. Calculating live scores now...'</p> : null}
         {this.props.searchLoaded && 
         <>
-        <HeaderTitle>@{this.props.searchResults.username}</HeaderTitle>
+        <HeaderTitle><img style={{width: '5vw', borderRadius: '50%'}} src={this.props.searchResults.image_url} alt="twitter profile picture" />@{this.props.searchResults.username}</HeaderTitle>
         <TabNavWrapper>
           <TabNav id="Personality" onClick={this.clickHandler}>
             Personality
@@ -126,11 +136,11 @@ class DataCard extends React.Component {
           </TabNav>
           </TabNavWrapper>
           <div>
-            {this.state.displayedData &&<SingleUserTraitsGraph data={objOfArr} /> }
+            {this.state.displayedData &&<SingleUserTraitsGraph data={this.chartDataFormat()} /> }
           </div>
         <div>
         {this.state.displayedData}
-          <p>{legend}</p>
+        {this.legendDataFormat()}
         </div>
         </>
         }

--- a/patt/src/components/SingleUserTraitsGraph.js
+++ b/patt/src/components/SingleUserTraitsGraph.js
@@ -2,6 +2,14 @@ import React from 'react'
 import { VictoryChart, VictoryArea, VictoryTheme, VictoryPolarAxis } from 'victory'
 
 export default function SingleUserTraitsGraph(props) {
+    const obj = props.data
+    const objOfArr = Object.keys(obj).map(key => {
+        return {
+            key: (key.charAt(0).toUpperCase() + key.slice(1).replace(/[^a-zA-Z ]/g, " ")),
+            value: obj[key]
+        }
+    })
+    console.log(objOfArr)
     return (
         <>
             <VictoryChart
@@ -11,7 +19,7 @@ export default function SingleUserTraitsGraph(props) {
             padding={{top:100, bottom:100, right:100, left:100}}
              >
                 <VictoryArea
-                data={props.data}
+                data={objOfArr}
                 x='key'
                 y="value"
                 animate

--- a/patt/src/components/TraitsLegend.js
+++ b/patt/src/components/TraitsLegend.js
@@ -40,6 +40,7 @@ export default function ExploreProfiles(props) {
             value: obj[key]
         }
     })
+    //conditionally render the color to match the score for each progress (red, yellow, green)
     const percent = objOfArr.map((trait, i) => {
         return <Progress
                     percent={trait.value*100}
@@ -58,36 +59,6 @@ export default function ExploreProfiles(props) {
                     <ProfileImage src={props.profilePic}/>
                     <ProfileLevels>
                         {percent}
-                        {/* <Progress
-                            percent={props.testResults.personality.conscientiousness*100}
-                            //percent={75}
-                            theme={{
-                                active: {
-                                symbol: 'conscientiousness',
-                                color: '#1EC56D'
-                                }
-                            }}
-                        />
-                        <Progress
-                            percent={props.testResults.needs.challenge*100}
-                            //percent={56}
-                            theme={{
-                                active: {
-                                symbol: 'challenge',
-                                color: '#FFD602'
-                                }
-                            }}
-                        />
-                        <Progress
-                            percent={props.testResults.needs.love*100}
-                            //percent={80}
-                            theme={{
-                                active: {
-                                symbol: 'love',
-                                color: '#CE46DD'
-                                }
-                            }}
-                        /> */}
                     </ProfileLevels>
                 </ProfileCard>
         </SearchWrapper>

--- a/patt/src/components/TraitsLegend.js
+++ b/patt/src/components/TraitsLegend.js
@@ -1,0 +1,95 @@
+import React, { Component } from 'react';
+import styled from 'styled-components';
+import { Progress } from 'react-sweet-progress';
+import "react-sweet-progress/lib/style.css";
+
+const SearchWrapper = styled.div`
+    background-color: white; 
+    max-width: 500px; 
+    width: 100%; 
+    margin: 30px auto; 
+    display: flex; 
+    flex-direction: column; 
+    text-align: center; 
+    align-items: center; 
+    font-family: 'Montserrat', sans-serif;
+`; 
+
+const ProfileCard = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center; 
+`;
+
+const ProfileImage = styled.img`
+    width: 60px;
+    border-radius: 50%;
+    margin-right: 20px; 
+`;
+
+const ProfileLevels = styled.div`
+    width: 300px; 
+`;
+
+export default function ExploreProfiles(props) {
+    console.log(props)
+    const obj = props.data
+    const objOfArr = Object.keys(obj).map(key => {
+        return {
+            key: (key.charAt(0).toUpperCase() + key.slice(1).replace(/[^a-zA-Z ]/g, " ")),
+            value: obj[key]
+        }
+    })
+    const percent = objOfArr.map((trait, i) => {
+        return <Progress
+                    percent={trait.value*100}
+                    theme={{
+                                active: {
+                                symbol: `${trait.key}`,
+                                color: '#1EC56D'
+                                }
+                            }}
+                    />
+    })
+    console.log(objOfArr)
+    return (
+        <SearchWrapper>
+                <ProfileCard>
+                    <ProfileImage src={props.profilePic}/>
+                    <ProfileLevels>
+                        {percent}
+                        {/* <Progress
+                            percent={props.testResults.personality.conscientiousness*100}
+                            //percent={75}
+                            theme={{
+                                active: {
+                                symbol: 'conscientiousness',
+                                color: '#1EC56D'
+                                }
+                            }}
+                        />
+                        <Progress
+                            percent={props.testResults.needs.challenge*100}
+                            //percent={56}
+                            theme={{
+                                active: {
+                                symbol: 'challenge',
+                                color: '#FFD602'
+                                }
+                            }}
+                        />
+                        <Progress
+                            percent={props.testResults.needs.love*100}
+                            //percent={80}
+                            theme={{
+                                active: {
+                                symbol: 'love',
+                                color: '#CE46DD'
+                                }
+                            }}
+                        /> */}
+                    </ProfileLevels>
+                </ProfileCard>
+        </SearchWrapper>
+    );
+}

--- a/patt/src/pages/LoginPage.js
+++ b/patt/src/pages/LoginPage.js
@@ -1,13 +1,11 @@
 import React from 'react'; 
 import { LoginForm } from '../components'; 
-import { Link } from 'react-router-dom'; 
  
 class LoginPage extends React.Component {
     render() {
         return(
             <> 
             <LoginForm /> 
-            {/* <Link to="/register"><button>Create account</button></Link> */}
             </> 
 
             )

--- a/patt/yarn.lock
+++ b/patt/yarn.lock
@@ -2466,6 +2466,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.5:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 clean-css@4.2.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.1.tgz#2d411ef76b8569b6d0c84068dabe85b0aa5e5c17"
@@ -8211,6 +8216,13 @@ react-scripts@3.0.1:
     workbox-webpack-plugin "4.2.0"
   optionalDependencies:
     fsevents "2.0.6"
+
+react-sweet-progress@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/react-sweet-progress/-/react-sweet-progress-1.1.2.tgz#b27c6baa7c08a12cf0896565431ba477af249892"
+  integrity sha512-FUfiKpox5LJ9YTeK/HsaLp/oOsuxWBJQir6oAYKLY5nsa2pb04PtxzddSy6Y1fn8osaILpXIcItJRQYnHp42CA==
+  dependencies:
+    classnames "^2.2.5"
 
 react@^16.8.6:
   version "16.8.6"


### PR DESCRIPTION
This PR includes the following changes-
deletion of /search-results route
insertion of dataCard component into the /search route
addition of custom react component, prototyped by clint, that is rendered underneath the singleUserTraitsGraph component. 

A bug has been found. Creating documentation to support how and where this is created. Current proposition to solution: Populate localStorage with data specific to the API calls, and then on page breaking/reload, rehydrate necessary redux store to allow for continued operation and a successful UI experience. 